### PR TITLE
Add Forza Horizon 5 car list site

### DIFF
--- a/data/fh5_cars.json
+++ b/data/fh5_cars.json
@@ -1,0 +1,4512 @@
+[
+  {
+    "brand": "Abarth",
+    "model": "Abarth 124 Spider",
+    "year": "2017"
+  },
+  {
+    "brand": "Abarth",
+    "model": "Abarth 595 esseesse",
+    "year": "1968"
+  },
+  {
+    "brand": "Abarth",
+    "model": "Abarth 695 Biposto",
+    "year": "2016"
+  },
+  {
+    "brand": "Abarth",
+    "model": "Abarth Fiat 131",
+    "year": "1980"
+  },
+  {
+    "brand": "Acura",
+    "model": "Acura Integra Type-R",
+    "year": "2001"
+  },
+  {
+    "brand": "Acura",
+    "model": "Acura NSX",
+    "year": "2017"
+  },
+  {
+    "brand": "Acura",
+    "model": "Acura RSX Type-S",
+    "year": "2002"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo 155 Q4",
+    "year": "1992"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo 33 Stradale",
+    "year": "1968"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo 4C",
+    "year": "2014"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo 8C Competizione",
+    "year": "2007"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo Giulia Quadrifoglio",
+    "year": "2017"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo Giulia Sprint GTA Stradale",
+    "year": "1965"
+  },
+  {
+    "brand": "Alfa",
+    "model": "Alfa Romeo Giulia TZ2",
+    "year": "1965"
+  },
+  {
+    "brand": "Alpine",
+    "model": "Alpine A110",
+    "year": "2017"
+  },
+  {
+    "brand": "Alpine",
+    "model": "Alpine A110 1600s",
+    "year": "1973"
+  },
+  {
+    "brand": "Alumicraft",
+    "model": "Alumicraft #122 Class 1 Buggy",
+    "year": "2021"
+  },
+  {
+    "brand": "Alumicraft",
+    "model": "Alumicraft #6165 Trick Truck",
+    "year": "2022"
+  },
+  {
+    "brand": "Alumicraft",
+    "model": "Alumicraft Class 10 Race Car",
+    "year": "2015"
+  },
+  {
+    "brand": "AMC",
+    "model": "AMC Gremlin X",
+    "year": "1973"
+  },
+  {
+    "brand": "AMC",
+    "model": "AMC Javelin AMX",
+    "year": "1971"
+  },
+  {
+    "brand": "AMC",
+    "model": "AMC Rebel \"The Machine\"",
+    "year": "1970"
+  },
+  {
+    "brand": "AMG",
+    "model": "AMG Transport Dynamics M12S Warthog CST",
+    "year": ""
+  },
+  {
+    "brand": "Apollo",
+    "model": "Apollo Intensa Emozione",
+    "year": "2018"
+  },
+  {
+    "brand": "Apollo",
+    "model": "Apollo Intensa Emozione \"Welcome Pack\"",
+    "year": "2018"
+  },
+  {
+    "brand": "Ariel",
+    "model": "Ariel Atom 500 V8",
+    "year": "2013"
+  },
+  {
+    "brand": "Ariel",
+    "model": "Ariel Nomad",
+    "year": "2016"
+  },
+  {
+    "brand": "Ascari",
+    "model": "Ascari KZ1R",
+    "year": "2012"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DB5",
+    "year": "1964"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DB11",
+    "year": "2017"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DBR1",
+    "year": "1958"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DBS",
+    "year": "2008"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DBS Superleggera",
+    "year": "2019"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin DBX",
+    "year": "2021"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Lagonda",
+    "year": "1990"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin One-77",
+    "year": "2010"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin V12 Vantage S",
+    "year": "2013"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Valhalla Concept Car",
+    "year": "2019"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Valkyrie",
+    "year": "2023"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Valkyrie AMR Pro",
+    "year": "2022"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Vanquish Zagato Coupé",
+    "year": "2017"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Vantage",
+    "year": "2019"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Vantage GT12",
+    "year": "2016"
+  },
+  {
+    "brand": "Aston",
+    "model": "Aston Martin Vulcan AMR Pro",
+    "year": "2017"
+  },
+  {
+    "brand": "ATS",
+    "model": "ATS GT",
+    "year": "2018"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi #2 Audi Sport quattro S1",
+    "year": "1986"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi R8 Coupé V10 plus 5.2 FSI quattro",
+    "year": "2013"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi R8 V10 plus",
+    "year": "2016"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi Avant RS2",
+    "year": "1995"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 3 Sedan",
+    "year": "2020"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 3 Sportback",
+    "year": "2011"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 4",
+    "year": "2006"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 4 Avant",
+    "year": "2001"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 4 Avant",
+    "year": "2013"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 4 Avant",
+    "year": "2018"
+  },
+  {
+    "brand": "Aido",
+    "model": "Aido RS 5 Coupé",
+    "year": "2011"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 5 Coupé",
+    "year": "2018"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 6",
+    "year": "2003"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 6",
+    "year": "2009"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 6 Avant",
+    "year": "2015"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 6 Avant",
+    "year": "2021"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 7 Sportback",
+    "year": "2013"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS 7 Sportback",
+    "year": "2021"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi RS e-tron GT",
+    "year": "2021"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi S1",
+    "year": "2015"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi Sport quattro",
+    "year": "1983"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi TT RS",
+    "year": "2018"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi TT RS Coupé",
+    "year": "2010"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi TT RS Coupe",
+    "year": "2020"
+  },
+  {
+    "brand": "Audi",
+    "model": "Audi TTS Coupé",
+    "year": "2015"
+  },
+  {
+    "brand": "Austin-Healey",
+    "model": "Austin-Healey Sprite MkI",
+    "year": "1958"
+  },
+  {
+    "brand": "Auto",
+    "model": "Auto Union Type D",
+    "year": "1939"
+  },
+  {
+    "brand": "Automobili",
+    "model": "Automobili Pininfarina Battista",
+    "year": "2020"
+  },
+  {
+    "brand": "Autozam",
+    "model": "Autozam AZ-1",
+    "year": "1993"
+  },
+  {
+    "brand": "BAC",
+    "model": "BAC Mono",
+    "year": "2014"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley 8 Litre",
+    "year": "1930"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Bentayga",
+    "year": "2016"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Blower 4-1/2 Litre Supercharged",
+    "year": "1931"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Continental GT Convertible",
+    "year": "2021"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Continental Supersports",
+    "year": "2017"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Flying Spur",
+    "year": "2021"
+  },
+  {
+    "brand": "Bentley",
+    "model": "Bentley Turbo R",
+    "year": "1991"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW #1 M Motorsport M8 GTE",
+    "year": "2018"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW 1 Series M Coupe",
+    "year": "2011"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW 2002 Turbo",
+    "year": "2002"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW 850CSi",
+    "year": "1995"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW i4 eDrive40",
+    "year": "2022"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW i8",
+    "year": "2015"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW Isetta 300 Export",
+    "year": "1957"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW iX xDrive50",
+    "year": "2022"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M1",
+    "year": "1981"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M2",
+    "year": "2023"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M2 Coupé",
+    "year": "2016"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3",
+    "year": "1991"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3",
+    "year": "1997"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3",
+    "year": "2005"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3",
+    "year": "2008"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3 Competition Sedan",
+    "year": "2021"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3-GTR",
+    "year": "2002"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M3 GTS",
+    "year": "2010"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M4 Competition Coupé",
+    "year": "2021"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M4 Coupé",
+    "year": "2014"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M4 GTS",
+    "year": "2016"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "1988"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "1995"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "2003"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "2009"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "2012"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5",
+    "year": "2018"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M5 CS",
+    "year": "2022"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M6 Coupe",
+    "year": "2013"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M635CSi",
+    "year": "1986"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW M8 Competition Coupe",
+    "year": "2020"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW X5 M",
+    "year": "2011"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW X5 M Forza Edition",
+    "year": "2011"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW X6 M",
+    "year": "2015"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW Z3 M Coupe",
+    "year": "2002"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW Z4",
+    "year": "2019"
+  },
+  {
+    "brand": "BMW",
+    "model": "BMW Z4 M Coupe",
+    "year": "2008"
+  },
+  {
+    "brand": "Brabham",
+    "model": "Brabham BT62",
+    "year": "2019"
+  },
+  {
+    "brand": "Bugatti",
+    "model": "Bugatti Chiron",
+    "year": "2018"
+  },
+  {
+    "brand": "Bugatti",
+    "model": "Bugatti Divo",
+    "year": "2019"
+  },
+  {
+    "brand": "Bugatti",
+    "model": "Bugatti EB110 Super Sport",
+    "year": "1992"
+  },
+  {
+    "brand": "Bugatti",
+    "model": "Bugatti Type 35 C",
+    "year": "1926"
+  },
+  {
+    "brand": "Bugatti",
+    "model": "Bugatti Veyron Super Sport",
+    "year": "2011"
+  },
+  {
+    "brand": "Buick",
+    "model": "Buick GSX",
+    "year": "1970"
+  },
+  {
+    "brand": "Buick",
+    "model": "Buick Regal GNX",
+    "year": "1987"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac #3 Cadillac Racing ATS-V.R",
+    "year": "2015"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac ATS-V",
+    "year": "2016"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac CT4-V Blackwing",
+    "year": "2022"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac CT5-V Blackwing",
+    "year": "2022"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac CTS-V Sedan",
+    "year": "2016"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac CTS-V Sport Wagon",
+    "year": "2014"
+  },
+  {
+    "brand": "Cadillac",
+    "model": "Cadillac XTS Limousine",
+    "year": "2013"
+  },
+  {
+    "brand": "Can-Am",
+    "model": "Can-Am Maverick X RS Turbo R",
+    "year": "2018"
+  },
+  {
+    "brand": "Casey",
+    "model": "Casey Currie Motorsports #4402 Ultra 4 'Trophy Jeep'",
+    "year": "2019"
+  },
+  {
+    "brand": "Caterham",
+    "model": "Caterham Superlight R500",
+    "year": "2013"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet #3 Corvette Racing C8.R",
+    "year": "2020"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet 150 Utility Sedan",
+    "year": "1955"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet \"Barbie Movie\" Corvette EV",
+    "year": "1956"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Bel Air",
+    "year": "1957"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro Super Sport Coupe",
+    "year": "1969"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro Jordan Luka 3 Forza Edition",
+    "year": "1969"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro Z/28",
+    "year": "2015"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro Z28",
+    "year": "1970"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro Z28",
+    "year": "1979"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro ZL1",
+    "year": "2017"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Camaro ZL1 1LE",
+    "year": "2018"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Chevelle Super Sport 454",
+    "year": "1970"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Colorado ZR2",
+    "year": "2017"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette",
+    "year": "1953"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette",
+    "year": "1960"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette E-Ray",
+    "year": "2024"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Forza Edition",
+    "year": "1953"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Stingray 427",
+    "year": "1967"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Stingray Coupé",
+    "year": "2020"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Z06",
+    "year": "2002"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Z06",
+    "year": "2015"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette Z06",
+    "year": "2023"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette ZR1",
+    "year": "2009"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette ZR1",
+    "year": "2019"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette ZR-1",
+    "year": "1970"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Corvette ZR-1",
+    "year": "1995"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet El Camino Super Sport 454",
+    "year": "1970"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Hot Wheels COPO Camaro",
+    "year": "2018"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Impala Super Sport",
+    "year": "1996"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Impala Super Sport 409",
+    "year": "1964"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet K-10 Custom",
+    "year": "1972"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Monte Carlo Super Sport",
+    "year": "1988"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Nova Super Sport 396",
+    "year": "1969"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Nova Super Sport",
+    "year": "1966"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Silverado LT Trail Boss",
+    "year": "2020"
+  },
+  {
+    "brand": "Chevrolet",
+    "model": "Chevrolet Summit Racing Pro Stock Camaro",
+    "year": "2013"
+  },
+  {
+    "brand": "Citroën",
+    "model": "Citroën BX 4TC",
+    "year": "1986"
+  },
+  {
+    "brand": "CUPRA",
+    "model": "CUPRA Formentor VZ5",
+    "year": "2021"
+  },
+  {
+    "brand": "CUPRA",
+    "model": "CUPRA Tavascan Concept",
+    "year": "2022"
+  },
+  {
+    "brand": "CUPRA",
+    "model": "CUPRA UrbanRebel Concept",
+    "year": "2022"
+  },
+  {
+    "brand": "Czinger",
+    "model": "Czinger 21C",
+    "year": "2024"
+  },
+  {
+    "brand": "Datsun",
+    "model": "Datsun 510",
+    "year": "1970"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Chevrolet C10 'Slayer'",
+    "year": "1965"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Chevrolet Silverado 1500 Drift Truck",
+    "year": "2018"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti F-150 Prerunner",
+    "year": "2018"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Ford Econoline 'Shop Rod'",
+    "year": "1961"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Ford Mustang GT",
+    "year": "2018"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Ford Super Duty F-250 Lariat 'Transformer'",
+    "year": "2019"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Toyota Tacoma TRD \"The Performance Truck\"",
+    "year": "2019"
+  },
+  {
+    "brand": "DeBerti",
+    "model": "DeBerti Wrangler Unlimited",
+    "year": "2013"
+  },
+  {
+    "brand": "DeLorean",
+    "model": "DeLorean DMC-12",
+    "year": "1982"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Challenger R/T",
+    "year": "1970"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Challenger SRT Demon",
+    "year": "2018"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Challenger SRT Hellcat",
+    "year": "2015"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Challenger SRT Super Stock",
+    "year": "2022"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Charger Daytona HEMI",
+    "year": "1969"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Charger R/T",
+    "year": "1969"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Charger R/T Forza Edition",
+    "year": "1969"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Charger SRT Hellcat",
+    "year": "2015"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Coronet Super Bee",
+    "year": "1970"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Dart HEMI Super Stock",
+    "year": "1968"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Durango SRT",
+    "year": "2018"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Durango SRT Hellcat",
+    "year": "2021"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Magnum SRT-8",
+    "year": "2008"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge SRT Viper GTS",
+    "year": "2013"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge SRT Viper GTS \"Anniversary Edition\"",
+    "year": "2013"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Viper ACR",
+    "year": "2016"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Viper GTS ACR",
+    "year": "1999"
+  },
+  {
+    "brand": "Dodge",
+    "model": "Dodge Viper SRT10 ACR",
+    "year": "2008"
+  },
+  {
+    "brand": "Donkervoort",
+    "model": "Donkervoort D8 GTO",
+    "year": "2013"
+  },
+  {
+    "brand": "DS",
+    "model": "DS 23",
+    "year": "1975"
+  },
+  {
+    "brand": "Eagle",
+    "model": "Eagle Speedster",
+    "year": "2012"
+  },
+  {
+    "brand": "Elemental",
+    "model": "Elemental RP1",
+    "year": "2019"
+  },
+  {
+    "brand": "Exomotive",
+    "model": "Exomotive Exocet Off-Road",
+    "year": "2018"
+  },
+  {
+    "brand": "Exomotive",
+    "model": "Exomotive Exocet Off-Road Forza Edition",
+    "year": "2018"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #5 Veloce Racing",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #6 Rosberg X Racing",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #22 JBXE",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #23 Genesys Andretti United",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #42 XITE Racing Team",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #44 X44",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #55 ACCIONA | Sainz XE Team",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #58 McLaren Racing",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #99 Chip Ganassi Racing GMC Hummer EV",
+    "year": "2022"
+  },
+  {
+    "brand": "Extreme",
+    "model": "Extreme E #125 ABT Cupra XE",
+    "year": "2022"
+  },
+  {
+    "brand": "Fast",
+    "model": "Fast and Furious Chevrolet Impala Super Sport 'Fast X'",
+    "year": "1966"
+  },
+  {
+    "brand": "Fast",
+    "model": "Fast and Furious Datsun 240Z 'Fast X'",
+    "year": "1973"
+  },
+  {
+    "brand": "Fast",
+    "model": "Fast and Furious Dodge Charger 'Fast X'",
+    "year": "1970"
+  },
+  {
+    "brand": "Fast",
+    "model": "Fast and Furious Dodge Charger SRT Hellcat Redeye Widebody 'Fast X'",
+    "year": "2022"
+  },
+  {
+    "brand": "Fast",
+    "model": "Fast and Furious Flip Car 2.0 'Fast X'",
+    "year": "2022"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari #24 Ferrari Spa 330 P4",
+    "year": "1967"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari #25 Corse Clienti 488 Challenge",
+    "year": "2017"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari #62 Risi Competizione 488 GTE",
+    "year": "2019"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 250 California",
+    "year": "1957"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 250 GT Berlinetta Lusso",
+    "year": "1962"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 250 GTO",
+    "year": "1962"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 250 Testa Rossa",
+    "year": "1957"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 288 GTO",
+    "year": "1984"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 296 GTB",
+    "year": "2022"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 360 Challenge Stradale",
+    "year": "2003"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 365 GTB/4",
+    "year": "1968"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 430 Scuderia",
+    "year": "2007"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 458 Italia",
+    "year": "2009"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 458 Speciale",
+    "year": "2013"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 488 GTB",
+    "year": "2015"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 488 Pista",
+    "year": "2019"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 512 S",
+    "year": "1970"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 512 TR",
+    "year": "1992"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 575M Maranello",
+    "year": "2002"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 599 GTO",
+    "year": "2010"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 599XX",
+    "year": "2010"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 599XX Evolution",
+    "year": "2012"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari 812 Superfast",
+    "year": "2017"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari California T",
+    "year": "2014"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari Dino 246 GT",
+    "year": "1969"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari Enzo Ferrari",
+    "year": "2002"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F12tdf",
+    "year": "2015"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F355 Berlinetta",
+    "year": "1994"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F40",
+    "year": "1987"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F40 Competizione",
+    "year": "1989"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F50",
+    "year": "1995"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F50 GT",
+    "year": "1996"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari F8 Tributo",
+    "year": "2020"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari FXX",
+    "year": "2005"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari FXX K",
+    "year": "2014"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari FXX-K Evo",
+    "year": "2018"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari GTC4Lusso",
+    "year": "2017"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari J50",
+    "year": "2017"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari LaFerrari",
+    "year": "2013"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari Monza SP2",
+    "year": "2019"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari Portofino",
+    "year": "2018"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari Roma",
+    "year": "2020"
+  },
+  {
+    "brand": "Ferrari",
+    "model": "Ferrari SF90 Stradale",
+    "year": "2020"
+  },
+  {
+    "brand": "FIAT",
+    "model": "FIAT 124 Sport Spider",
+    "year": "1980"
+  },
+  {
+    "brand": "FIAT",
+    "model": "FIAT Dino 2.4 Coupe",
+    "year": "1969"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #2 GT40 MK II",
+    "year": "1966"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #4 Ford Focus RS",
+    "year": "2001"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #5 Escort RS1800 MKII",
+    "year": "1977"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #11 Rockstar F-150 Trophy Truck",
+    "year": "2014"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #14 Rahal Letterman Lanigan Racing GRC Fiesta",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #25 \"Brocky\" Ultra4 Bronco RTR",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #25 Mustang RTR",
+    "year": "2018"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #66 GTLM Le Mans",
+    "year": "2016"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #88 Mustang RTR",
+    "year": "2018"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #2069 Ford Performance Bronco R",
+    "year": "2069"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford #2069 Ford Bronco R \"Welcome Pack\"",
+    "year": "2069"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Anglia 105E",
+    "year": "1959"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Bronco",
+    "year": "1975"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Bronco",
+    "year": "2021"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Bronco Raptor",
+    "year": "2022"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Capri RS3100",
+    "year": "1973"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Crown Victoria Police Interceptor",
+    "year": "2010"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford De Luxe Coupe",
+    "year": "1940"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford De Luxe Five-Window Coupe",
+    "year": "1932"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford De Luxe Five-Window Coupe Forza Edition",
+    "year": "1932"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Escort RS Cosworth",
+    "year": "1992"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Escort RS Turbo",
+    "year": "1986"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Escort RS1600",
+    "year": "1973"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Escort RS1800",
+    "year": "1977"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-100",
+    "year": "1965"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 Lightning Platinum",
+    "year": "2022"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 Raptor",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 Raptor R",
+    "year": "2023"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 SVT Lightning",
+    "year": "2003"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 SVT Raptor",
+    "year": "2011"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford F-150 XLT Lariat",
+    "year": "1986"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Falcon GT F 351",
+    "year": "2015"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Falcon XA GT-HO",
+    "year": "1972"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Fiesta ST",
+    "year": "2014"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Fiesta ST",
+    "year": "2023"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Fiesta XR2",
+    "year": "1981"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Focus RS",
+    "year": "2003"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Focus RS",
+    "year": "2009"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Focus RS",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Focus ST",
+    "year": "2022"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford FPV Limited Edition Pursuit Ute",
+    "year": "2014"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford GT",
+    "year": "2005"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford GT",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford GT \"OPI Edition\"",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford GT40 Mk I",
+    "year": "1964"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford GT70",
+    "year": "1970"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Lotus Cortina",
+    "year": "1966"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford M-Sport Fiesta RS",
+    "year": "2017"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang Boss 302",
+    "year": "1969"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang Dark Horse",
+    "year": "2024"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang GT",
+    "year": "2018"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang GT",
+    "year": "2024"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang GT 2+2 Fastback",
+    "year": "1968"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang GT Coupe",
+    "year": "1965"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang Mach 1",
+    "year": "1971"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang Mach-E 1400",
+    "year": "2021"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang RTR Spec 5",
+    "year": "2018"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang Shelby GT500",
+    "year": "2020"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang SVO",
+    "year": "1986"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang SVT Cobra",
+    "year": "2003"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Mustang SVT Cobra R",
+    "year": "1995"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Racing Escort Mk1",
+    "year": "1967"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Racing Puma",
+    "year": "1999"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Racing Puma Forza Edition",
+    "year": "1999"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Ranger Raptor",
+    "year": "2019"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Ranger T6 Rally Raid",
+    "year": "2014"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford RS200 Evolution",
+    "year": "1985"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Shelby GT350R",
+    "year": "2016"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Shelby GT500",
+    "year": "2013"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Sierra Cosworth RS500",
+    "year": "1987"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Super Deluxe Station Wagon",
+    "year": "1946"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Super Duty F-450 DRW Platinum",
+    "year": "2020"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Supervan 3",
+    "year": "1994"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Supervan 3 'Donut Media Edition'",
+    "year": "1994"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Supervan 4",
+    "year": "2022"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford SVT Cobra R",
+    "year": "1993"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford SVT Cobra R",
+    "year": "2000"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Transit",
+    "year": "1965"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford Transit SuperSportVan",
+    "year": "2011"
+  },
+  {
+    "brand": "Ford",
+    "model": "Ford XB Falcon GT",
+    "year": "1973"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #13 Ford Mustang",
+    "year": "2015"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #34 Toyota Supra MkIV",
+    "year": "1995"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #43 Dodge Viper SRT10",
+    "year": "2006"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #51 Donut Media Nissan 240SX",
+    "year": "1996"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #64 Forsberg Racing Nissan Z",
+    "year": "2023"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #64 Nissan 370Z",
+    "year": "2018"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #91 BMW M2",
+    "year": "2020"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #98 BMW 325i",
+    "year": "1989"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #99 Mazda RX-8",
+    "year": "2009"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #117 599 GTB Fiorano",
+    "year": "2007"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #151 Toyota GR Supra",
+    "year": "2020"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #357 Chevrolet Corvette Z06",
+    "year": "2017"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #411 Toyota Corolla Hatchback",
+    "year": "2019"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #530 HSV Maloo Gen-F",
+    "year": "2016"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #777 Chevrolet Corvette",
+    "year": "2013"
+  },
+  {
+    "brand": "Formula",
+    "model": "Formula Drift #777 Nissan 240SX",
+    "year": "1997"
+  },
+  {
+    "brand": "Forsberg",
+    "model": "Forsberg Racing Nissan 'Altimaniac'",
+    "year": "2021"
+  },
+  {
+    "brand": "Forsberg",
+    "model": "Forsberg Racing Nissan 'Gold Leader' Datsun 280Z",
+    "year": "1975"
+  },
+  {
+    "brand": "Forsberg",
+    "model": "Forsberg Racing Nissan 'SafariZ' 370Z Safari Rally Tribute",
+    "year": "2014"
+  },
+  {
+    "brand": "Forsberg",
+    "model": "Forsberg Racing Toyota Gumout 2JZ Camry Stock Car",
+    "year": "2010"
+  },
+  {
+    "brand": "Funco",
+    "model": "Funco Motorsports F9",
+    "year": "2018"
+  },
+  {
+    "brand": "Ginetta",
+    "model": "Ginetta G10 RM",
+    "year": "2019"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC \"Barbie Movie\" HUMMER EV Pickup",
+    "year": "2022"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC HUMMER EV Pickup",
+    "year": "2022"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC Jimmy",
+    "year": "1970"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC Syclone",
+    "year": "1991"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC Typhoon",
+    "year": "1992"
+  },
+  {
+    "brand": "GMC",
+    "model": "GMC Vandura G-1500",
+    "year": "1983"
+  },
+  {
+    "brand": "Gordon",
+    "model": "Gordon Murray Automotive T.50",
+    "year": "2022"
+  },
+  {
+    "brand": "HDT",
+    "model": "HDT VK Commodore Group A",
+    "year": "1985"
+  },
+  {
+    "brand": "Hennessey",
+    "model": "Hennessey Camaro Exorcist",
+    "year": "2019"
+  },
+  {
+    "brand": "Hennessey",
+    "model": "Hennessey Mammoth 1000 6x6 TRX",
+    "year": "2022"
+  },
+  {
+    "brand": "Hennessey",
+    "model": "Hennessey VelociRaptor 6x6",
+    "year": "2019"
+  },
+  {
+    "brand": "Hennessey",
+    "model": "Hennessey Venom F5",
+    "year": "2021"
+  },
+  {
+    "brand": "Hennessey",
+    "model": "Hennessey Venom GT",
+    "year": "2012"
+  },
+  {
+    "brand": "Holden",
+    "model": "Holden HQ Monaro GTS 350",
+    "year": "1973"
+  },
+  {
+    "brand": "Holden",
+    "model": "Holden Sandman HQ Panelvan",
+    "year": "1974"
+  },
+  {
+    "brand": "Holden",
+    "model": "Holden Torana A9X",
+    "year": "1977"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Coupe",
+    "year": "2016"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic CRX Mugen",
+    "year": "1984"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic RS",
+    "year": "1974"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Type R",
+    "year": "1997"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Type R",
+    "year": "2004"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Type R",
+    "year": "2007"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Type R",
+    "year": "2016"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Civic Type R",
+    "year": "2018"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda CR-X SiR",
+    "year": "1991"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda NSX-R",
+    "year": "1992"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda NSX-R",
+    "year": "2005"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda NSX-R GT",
+    "year": "2005"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Prelude Si",
+    "year": "1994"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda Ridgeline Baja Trophy Truck",
+    "year": "2015"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda S2000",
+    "year": "2000"
+  },
+  {
+    "brand": "Honda",
+    "model": "Honda S2000 CR",
+    "year": "2000"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Chevrolet Bel Air",
+    "year": "1955"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Chevrolet Napalm Nova",
+    "year": "1972"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Ford Escort Cosworth WRC \"Cossie V2\"",
+    "year": "1994"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Ford Escort RS1800",
+    "year": "1978"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Ford \"Hoonicorn\" Mustang",
+    "year": "1965"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Ford RS200 Evolution",
+    "year": "1986"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Gymkhana 9 Ford Focus RS RX",
+    "year": "2016"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Gymkhana 10 Ford Escort Cosworth Group A",
+    "year": "1991"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Gymkhana 10 Ford F-150 'Hoonitruck'",
+    "year": "1965"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Gymkhana 10 Ford Focus RS RX",
+    "year": "2016"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Gymkhana 10 Ford Hoonicorn Mustang",
+    "year": "1965"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Mazda RX-7 Twerkstallion",
+    "year": "1992"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Rauh-Welt Begriff Porsche 911 Turbo",
+    "year": "1991"
+  },
+  {
+    "brand": "Hoonigan",
+    "model": "Hoonigan Volkswagen Baja Beetle Class 5/1600 'Scumbug'",
+    "year": "1973"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels 2JetZ",
+    "year": "2018"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Bad to the Blade",
+    "year": "2012"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Baja Bone Shaker",
+    "year": "2013"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Bone Shaker",
+    "year": "2011"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Deora II",
+    "year": "2000"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Ford F-5 Dually Custom Hot Rod",
+    "year": "1949"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Ford Mustang",
+    "year": "2005"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Nash Metropolitan Custom",
+    "year": "1957"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Pontiac Firebird Trans Am Custom",
+    "year": "1970"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Rip Rod",
+    "year": "2012"
+  },
+  {
+    "brand": "Hot",
+    "model": "Hot Wheels Twin Mill",
+    "year": "1969"
+  },
+  {
+    "brand": "HSV",
+    "model": "HSV GEN-F GTS",
+    "year": "2014"
+  },
+  {
+    "brand": "HSV",
+    "model": "HSV Limited Edition Gen-F GTS Maloo",
+    "year": "2014"
+  },
+  {
+    "brand": "Hummer",
+    "model": "Hummer H1 Alpha",
+    "year": "2006"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai #98 Bryan Herta Autosport Elantra N",
+    "year": "2021"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai i30 N",
+    "year": "2020"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai IONIQ 5 N",
+    "year": "2023"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai IONIQ 6",
+    "year": "2022"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai Kona N",
+    "year": "2022"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai N Vision 74",
+    "year": "2022"
+  },
+  {
+    "brand": "Hyundai",
+    "model": "Hyundai Veloster N",
+    "year": "2019"
+  },
+  {
+    "brand": "Infiniti",
+    "model": "Infiniti Q60 Concept",
+    "year": "2015"
+  },
+  {
+    "brand": "International",
+    "model": "International Scout 800A",
+    "year": "1970"
+  },
+  {
+    "brand": "Italdesign",
+    "model": "Italdesign DaVinci Concept",
+    "year": "2019"
+  },
+  {
+    "brand": "Italdesign",
+    "model": "Italdesign Zerouno",
+    "year": "2018"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar C-Type",
+    "year": "1953"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar C-X75",
+    "year": "2010"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar D-Type",
+    "year": "1956"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar E-type",
+    "year": "1961"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar F-PACE S",
+    "year": "2017"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar F-TYPE Project 7",
+    "year": "2016"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar F-TYPE R Coupé",
+    "year": "2015"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar F-TYPE SVR",
+    "year": "2020"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar I-Pace",
+    "year": "2018"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar Lightweight E-Type",
+    "year": "1964"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar Mk II 3.8",
+    "year": "1959"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar Sport XJR-15",
+    "year": "1991"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XE SV Project 8",
+    "year": "2019"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XE-S",
+    "year": "2015"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XFR-S",
+    "year": "2015"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XJ13",
+    "year": "1966"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XJ220",
+    "year": "1993"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XJ220S TWR",
+    "year": "1993"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XKR-S",
+    "year": "2012"
+  },
+  {
+    "brand": "Jaguar",
+    "model": "Jaguar XKR-S GT",
+    "year": "2015"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep CJ5 Renegade",
+    "year": "1976"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep Grand Cherokee SRT",
+    "year": "2014"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep Grand Cherokee Trackhawk",
+    "year": "2018"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep Gladiator Rubicon",
+    "year": "2020"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep Trailcat",
+    "year": "2016"
+  },
+  {
+    "brand": "Jeep",
+    "model": "Jeep Wrangler Rubicon",
+    "year": "2012"
+  },
+  {
+    "brand": "Jimco",
+    "model": "Jimco #179 Hammerhead Class 1",
+    "year": "2020"
+  },
+  {
+    "brand": "Jimco",
+    "model": "Jimco #240 Fastball Racing Spec Trophy Truck",
+    "year": "2019"
+  },
+  {
+    "brand": "Kia",
+    "model": "Kia EV6 GT",
+    "year": "2023"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg Agera",
+    "year": "2011"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg Agera RS",
+    "year": "2017"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg CC8S",
+    "year": "2002"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg CCGT",
+    "year": "2008"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg CCX",
+    "year": "2006"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg Jesko",
+    "year": "2020"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg One:1",
+    "year": "2015"
+  },
+  {
+    "brand": "Koenigsegg",
+    "model": "Koenigsegg Regera",
+    "year": "2016"
+  },
+  {
+    "brand": "KTM",
+    "model": "KTM X-Bow GT2",
+    "year": "2020"
+  },
+  {
+    "brand": "KTM",
+    "model": "KTM X-Bow GT4",
+    "year": "2018"
+  },
+  {
+    "brand": "KTM",
+    "model": "KTM X-Bow R",
+    "year": "2013"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini #63 Squadra Corse Huracán Super Trofeo Evo",
+    "year": "2018"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Aventador J",
+    "year": "2012"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Aventador LP700-4",
+    "year": "2012"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Aventador LP 780-4 Ultimae",
+    "year": "2021"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Aventador Superveloce",
+    "year": "2016"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Aventador SVJ",
+    "year": "2018"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Centenario LP 770-4",
+    "year": "2016"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Countach LP5000 QV",
+    "year": "1988"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Countach LPI 800-4",
+    "year": "2021"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Diablo GTR",
+    "year": "1999"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Diablo SV",
+    "year": "1997"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Espada 400 GT",
+    "year": "1973"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Essenza SCV12",
+    "year": "2020"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Gallardo LP 570-4 Spyder Performante",
+    "year": "2012"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Gallardo LP 570-4 Superleggera",
+    "year": "2011"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán EVO",
+    "year": "2020"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán LP 610-4",
+    "year": "2014"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán Performante",
+    "year": "2018"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán Sterrato",
+    "year": "2023"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán STO",
+    "year": "2020"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Huracán Tecnica",
+    "year": "2023"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini LM 002",
+    "year": "1986"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Miura P400",
+    "year": "1967"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Murciélago LP 670-4 SV",
+    "year": "2010"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Reventón",
+    "year": "2008"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Revuelto",
+    "year": "2024"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini SC20",
+    "year": "2020"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Sesto Elemento",
+    "year": "2011"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Sesto Elemento Forza Edition",
+    "year": "2011"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Sián Roadster",
+    "year": "2020"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Urus",
+    "year": "2019"
+  },
+  {
+    "brand": "Lamborghini",
+    "model": "Lamborghini Veneno",
+    "year": "2013"
+  },
+  {
+    "brand": "Lancia",
+    "model": "Lancia 037 Stradale",
+    "year": "1982"
+  },
+  {
+    "brand": "Lancia",
+    "model": "Lancia Delta HF Integrale Evo",
+    "year": "1992"
+  },
+  {
+    "brand": "Lancia",
+    "model": "Lancia Delta S4",
+    "year": "1986"
+  },
+  {
+    "brand": "Lancia",
+    "model": "Lancia Fulvia Coupé Rallye 1.6 HF",
+    "year": "1968"
+  },
+  {
+    "brand": "Lancia",
+    "model": "Lancia Stratos HF Stradale",
+    "year": "1974"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Defender 90",
+    "year": "1997"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Defender 110 X",
+    "year": "2020"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Range Rover",
+    "year": "1973"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Range Rover Sport SVR",
+    "year": "2015"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Range Rover Velar First Edition",
+    "year": "2018"
+  },
+  {
+    "brand": "Land",
+    "model": "Land Rover Series III",
+    "year": "1997"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus #14 VASSER SULLIVAN RC F GT3",
+    "year": "2020"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus LC 500",
+    "year": "2021"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus LFA",
+    "year": "2010"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus RC F",
+    "year": "2015"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus RC F Track Edition",
+    "year": "2020"
+  },
+  {
+    "brand": "Lexus",
+    "model": "Lexus SC300",
+    "year": "1997"
+  },
+  {
+    "brand": "Lincoln",
+    "model": "Lincoln Continental",
+    "year": "1962"
+  },
+  {
+    "brand": "Local",
+    "model": "Local Motors Rally Fighter",
+    "year": "2014"
+  },
+  {
+    "brand": "Lola",
+    "model": "Lola #6 Penske Sunoco T70 MkIIIB",
+    "year": "1969"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus 2-Eleven",
+    "year": "2009"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus 3-Eleven",
+    "year": "2016"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus 340R",
+    "year": "2000"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Elan Sprint",
+    "year": "1971"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Elise GT1",
+    "year": "1997"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Elise Series 1 Sport 190",
+    "year": "1999"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Emira",
+    "year": "2023"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Esprit Turbo",
+    "year": "1980"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Esprit V8",
+    "year": "2002"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Evija",
+    "year": "2020"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Exige Cup 430",
+    "year": "2018"
+  },
+  {
+    "brand": "Lotus",
+    "model": "Lotus Exige S",
+    "year": "2012"
+  },
+  {
+    "brand": "Lucid",
+    "model": "Lucid Air Sapphire",
+    "year": "2023"
+  },
+  {
+    "brand": "Lynk",
+    "model": "Lynk & Co #100 Cyan Racing 03",
+    "year": "2020"
+  },
+  {
+    "brand": "Lynk",
+    "model": "Lynk & Co 02 Hatchback",
+    "year": "2022"
+  },
+  {
+    "brand": "Lynk",
+    "model": "Lynk & Co 03+",
+    "year": "2021"
+  },
+  {
+    "brand": "Lynk",
+    "model": "Lynk & Co 05+",
+    "year": "2022"
+  },
+  {
+    "brand": "Maserati",
+    "model": "Maserati 8CTF",
+    "year": "1939"
+  },
+  {
+    "brand": "Maserati",
+    "model": "Maserati Gran Turismo S",
+    "year": "2010"
+  },
+  {
+    "brand": "Maserati",
+    "model": "Maserati Gran Turismo S Forza Edition",
+    "year": "2010"
+  },
+  {
+    "brand": "Maserati",
+    "model": "Maserati Levante S",
+    "year": "2017"
+  },
+  {
+    "brand": "Maserati",
+    "model": "Maserati MC12 Versione Corsa",
+    "year": "2008"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda 323 GT-R",
+    "year": "1992"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda Mazdaspeed MX-5",
+    "year": "2005"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda MX-5",
+    "year": "2013"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda MX-5",
+    "year": "2016"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda MX-5 Miata",
+    "year": "1994"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda MX-5 Miata RF",
+    "year": "2022"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda RX-7",
+    "year": "1997"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda RX-7 Spirit R Type-A",
+    "year": "2002"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda RX-8 R3",
+    "year": "2011"
+  },
+  {
+    "brand": "Mazda",
+    "model": "Mazda Savanna RX-7",
+    "year": "1990"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 12C Coupé",
+    "year": "2011"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 570S Coupé",
+    "year": "2015"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 600LT Coupé",
+    "year": "2018"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 620R",
+    "year": "2021"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 650S Coupé",
+    "year": "2015"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 650S Spider",
+    "year": "2014"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 720S Coupé",
+    "year": "2018"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 720S Spider",
+    "year": "2019"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren 765LT",
+    "year": "2021"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren Artura",
+    "year": "2023"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren F1",
+    "year": "1993"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren F1 GT",
+    "year": "1997"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren GT",
+    "year": "2020"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren P1",
+    "year": "2013"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren Sabre",
+    "year": "2021"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren Senna",
+    "year": "2018"
+  },
+  {
+    "brand": "McLaren",
+    "model": "McLaren Speedtail",
+    "year": "2019"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG C 63 S Coupé",
+    "year": "2016"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG E 63 S",
+    "year": "2018"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG GT 4-Door Coupé",
+    "year": "2018"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG GT Black Series",
+    "year": "2021"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG GT R",
+    "year": "2017"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG GT S",
+    "year": "2015"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG GT3",
+    "year": "2018"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG Mercedes-AMG ONE",
+    "year": "2021"
+  },
+  {
+    "brand": "Mercedes-AMG",
+    "model": "Mercedes-AMG SL 63",
+    "year": "2021"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz #24 Tankpool24 Racing Truck",
+    "year": "2015"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz #24 Tankpool24 Racing Truck Forza Edition",
+    "year": "2015"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz 190E 2.5-16 Evolution II",
+    "year": "1990"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz 280 SL",
+    "year": "1967"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz 300 SL Coupé",
+    "year": "1954"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz 300 SLR",
+    "year": "1955"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz 500 E",
+    "year": "1992"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz A 45 AMG",
+    "year": "2013"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz AMG CLK GTR",
+    "year": "1998"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz AMG CLK GTR Forza Edition",
+    "year": "1998"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz AMG Hammer Coupe",
+    "year": "1987"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz AMG Hammer Wagon",
+    "year": "1987"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz C 63 AMG Coupé Black Series",
+    "year": "2012"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz E 55 AMG Wagon",
+    "year": "2006"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz E 63 AMG",
+    "year": "2013"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz G 63 AMG 6x6",
+    "year": "2014"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz G 65 AMG",
+    "year": "2013"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz SL 65 AMG Black Series",
+    "year": "2009"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz SLK 55 AMG",
+    "year": "2012"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz SLS AMG",
+    "year": "2011"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz SSK",
+    "year": "1929"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz Unimog U5023",
+    "year": "2014"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz W154",
+    "year": "1939"
+  },
+  {
+    "brand": "Mercedes-Benz",
+    "model": "Mercedes-Benz X-Class",
+    "year": "2018"
+  },
+  {
+    "brand": "Mercury",
+    "model": "Mercury Cyclone Spoiler",
+    "year": "1970"
+  },
+  {
+    "brand": "Meyers",
+    "model": "Meyers Manx",
+    "year": "1971"
+  },
+  {
+    "brand": "Meyers",
+    "model": "Meyers Manx Forza Edition",
+    "year": "1971"
+  },
+  {
+    "brand": "Meyers",
+    "model": "Meyers Manx 2.0 EV",
+    "year": "2023"
+  },
+  {
+    "brand": "MG",
+    "model": "MG #20 MG6 XPower",
+    "year": "2020"
+  },
+  {
+    "brand": "MG",
+    "model": "MG Cyberster",
+    "year": "2023"
+  },
+  {
+    "brand": "MG",
+    "model": "MG Metro 6R4",
+    "year": "1986"
+  },
+  {
+    "brand": "MG",
+    "model": "MG MG3",
+    "year": "2015"
+  },
+  {
+    "brand": "MG",
+    "model": "MG MG6 XPower",
+    "year": "2021"
+  },
+  {
+    "brand": "MG",
+    "model": "MG MG7",
+    "year": "2022"
+  },
+  {
+    "brand": "MG",
+    "model": "MG XPower SV-R",
+    "year": "2005"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI Cooper S",
+    "year": "1965"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI Cooper S Forza Edition",
+    "year": "1965"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI John Cooper Works",
+    "year": "2009"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI John Cooper Works Countryman All4",
+    "year": "2018"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI John Cooper Works GP",
+    "year": "2012"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI John Cooper Works GP",
+    "year": "2021"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI X-Raid All4 Racing Countryman",
+    "year": "2014"
+  },
+  {
+    "brand": "MINI",
+    "model": "MINI X-Raid John Cooper Works Buggy",
+    "year": "2018"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi #1 Sierra Sierra Enterprises Lancer Evolution Time Attack",
+    "year": "2005"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Eclipse GSX",
+    "year": "1995"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi FTO GP Version R",
+    "year": "1998"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Galant VR-4",
+    "year": "1992"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi GTO",
+    "year": "1997"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution III GSR",
+    "year": "1995"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution VI GSR",
+    "year": "1999"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution VIII MR",
+    "year": "2004"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution IX MR",
+    "year": "2006"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution X GSR",
+    "year": "2008"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Lancer Evolution X GSR \"Welcome Pack\"",
+    "year": "2008"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Montero Evolution",
+    "year": "1997"
+  },
+  {
+    "brand": "Mitsubishi",
+    "model": "Mitsubishi Starion ESI-R",
+    "year": "1998"
+  },
+  {
+    "brand": "Morgan",
+    "model": "Morgan 3 Wheeler",
+    "year": "2014"
+  },
+  {
+    "brand": "Morgan",
+    "model": "Morgan Aero GT",
+    "year": "2018"
+  },
+  {
+    "brand": "Morris",
+    "model": "Morris Mini-Traveller",
+    "year": "1965"
+  },
+  {
+    "brand": "Morris",
+    "model": "Morris Minor 1000",
+    "year": "1958"
+  },
+  {
+    "brand": "Morris",
+    "model": "Morris Minor 1000 Forza Edition",
+    "year": "1958"
+  },
+  {
+    "brand": "Morris",
+    "model": "Morris Minor Series II Traveler",
+    "year": "1953"
+  },
+  {
+    "brand": "Mosler",
+    "model": "Mosler MT900 GT3",
+    "year": "2006"
+  },
+  {
+    "brand": "Mosler",
+    "model": "Mosler MT900S",
+    "year": "2010"
+  },
+  {
+    "brand": "Napier",
+    "model": "Napier Napier-Railton",
+    "year": "1933"
+  },
+  {
+    "brand": "NIO",
+    "model": "NIO EP9",
+    "year": "2016"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan 240SX SE",
+    "year": "1993"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan 370Z",
+    "year": "2010"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan 370Z NISMO",
+    "year": "2019"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Be-1",
+    "year": "1987"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Donut Media 350Z 'Hi Car'",
+    "year": "2004"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Donut Media 350Z 'Low Car'",
+    "year": "2004"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Fairlady Z",
+    "year": "2003"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Fairlady Z Forza Edition",
+    "year": "2003"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Fairlady Z 432",
+    "year": "1969"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Fairlady Z Version S Twin Turbo",
+    "year": "1994"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Figaro",
+    "year": "1991"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan GT-R (R35)",
+    "year": "2017"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan GT-R Black Edition (R35)",
+    "year": "2012"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan GT-R NISMO (R35)",
+    "year": "2020"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan NISMO GT-R LM",
+    "year": "1995"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Pao",
+    "year": "1989"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Pulsar GTI-R",
+    "year": "1990"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Pickup #23 Rally Raid",
+    "year": "2004"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan R390 (GT1)",
+    "year": "1998"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan S-Cargo",
+    "year": "1989"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Safari Turbo",
+    "year": "1985"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Sentra NISMO",
+    "year": "2018"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Silvia CLUB K's",
+    "year": "1992"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Silvia K's",
+    "year": "1994"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Silvia K's AERO",
+    "year": "1998"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Silvia Spec-R",
+    "year": "2000"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline 2000GT-R",
+    "year": "2000"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline GT-R V-Spec",
+    "year": "1993"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline GT-R V-Spec",
+    "year": "1997"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline GT-R V-Spec II",
+    "year": "2002"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline GTS-R (HR31)",
+    "year": "1987"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Skyline H/T 2000GT-R",
+    "year": "2000"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Stagea RS Four V",
+    "year": "1997"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan TITAN Warrior Concept",
+    "year": "2016"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Tsuru",
+    "year": "2010"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Z",
+    "year": "2023"
+  },
+  {
+    "brand": "Nissan",
+    "model": "Nissan Z NISMO",
+    "year": "2024"
+  },
+  {
+    "brand": "Noble",
+    "model": "Noble M400",
+    "year": "2006"
+  },
+  {
+    "brand": "Noble",
+    "model": "Noble M600",
+    "year": "2010"
+  },
+  {
+    "brand": "Oldsmobile",
+    "model": "Oldsmobile Toronado",
+    "year": "1966"
+  },
+  {
+    "brand": "Opel",
+    "model": "Opel Manta 400",
+    "year": "1984"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Huayra BC Coupe",
+    "year": "2016"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Huayra BC Forza Edition",
+    "year": "2016"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Huayra Coupe",
+    "year": "2011"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Huayra R",
+    "year": "2022"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Zonda Cinque Roadster",
+    "year": "2010"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Zonda Cinque Roadster \"Oreo Edition\"",
+    "year": "2009"
+  },
+  {
+    "brand": "Pagani",
+    "model": "Pagani Zonda R",
+    "year": "2009"
+  },
+  {
+    "brand": "Peel",
+    "model": "Peel P50",
+    "year": "1962"
+  },
+  {
+    "brand": "Peel",
+    "model": "Peel Trident",
+    "year": "1965"
+  },
+  {
+    "brand": "Penhall",
+    "model": "Penhall The Cholla",
+    "year": "2011"
+  },
+  {
+    "brand": "Peugeot",
+    "model": "Peugeot 205 Rallye",
+    "year": "1991"
+  },
+  {
+    "brand": "Peugeot",
+    "model": "Peugeot 205 Turbo 16",
+    "year": "1984"
+  },
+  {
+    "brand": "Peugeot",
+    "model": "Peugeot 207 Super 2000",
+    "year": "2000"
+  },
+  {
+    "brand": "Plymouth",
+    "model": "Plymouth Barracuda Formula-S",
+    "year": "1968"
+  },
+  {
+    "brand": "Plymouth",
+    "model": "Plymouth Belvedere",
+    "year": "1964"
+  },
+  {
+    "brand": "Plymouth",
+    "model": "Plymouth Cuda 426 HEMI",
+    "year": "1971"
+  },
+  {
+    "brand": "Plymouth",
+    "model": "Plymouth Fury",
+    "year": "1958"
+  },
+  {
+    "brand": "Polaris",
+    "model": "Polaris RZR Pro XP Factory Racing Limited Edition",
+    "year": "2021"
+  },
+  {
+    "brand": "Polaris",
+    "model": "Polaris RZR Pro XP Ultimate",
+    "year": "2021"
+  },
+  {
+    "brand": "Polaris",
+    "model": "Polaris RZR XP 1000 EPS",
+    "year": "2015"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac Firebird",
+    "year": "1968"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac Firebird Trans Am",
+    "year": "1977"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac Firebird Trans Am GTA",
+    "year": "1987"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac Firebird Trans Am GTA Forza Edition",
+    "year": "1987"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac Firebird Trans Am SD-455",
+    "year": "1973"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac GTO",
+    "year": "1965"
+  },
+  {
+    "brand": "Pontiac",
+    "model": "Pontiac GTO Judge",
+    "year": "1969"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #3 917 LH",
+    "year": "1970"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #23 917/20",
+    "year": "1971"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #46 356 SL Gmünd Coupe",
+    "year": "1951"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #65 Rothsport Racing 911 \"Desert Flyer\"",
+    "year": "1989"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #70 Porsche Motorsport 935",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #92 GT Team 911 RSR",
+    "year": "2017"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche #185 959 Prodrive Rally Raid",
+    "year": "1986"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 356 A 1600 Super",
+    "year": "1959"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 356 C Cabriolet Emory Special",
+    "year": "1960"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 550 Spyder",
+    "year": "1955"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 718 Cayman GT4 RS",
+    "year": "2022"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 718 Cayman GTS",
+    "year": "2018"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 906 Carrera 6",
+    "year": "1966"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Carrera 2 by Gunther Werks",
+    "year": "1995"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Carrera RS",
+    "year": "1973"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Carrera S",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT1 Strassenversion",
+    "year": "1997"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT2",
+    "year": "1995"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT2 RS",
+    "year": "2012"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT2 RS",
+    "year": "2018"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3",
+    "year": "2004"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3",
+    "year": "2021"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 R",
+    "year": "2018"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 R",
+    "year": "2023"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 RS",
+    "year": "2016"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 RS",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 RS",
+    "year": "2023"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 RS 4.0",
+    "year": "2012"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 GT3 RS Forza Edition",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Rallye",
+    "year": "2023"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Reimagined by Singer - DLS",
+    "year": "1990"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Speedster",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Sport Classic",
+    "year": "2010"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Turbo 3.3",
+    "year": "1982"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Turbo S",
+    "year": "2014"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 911 Turbo S",
+    "year": "2023"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 914/6",
+    "year": "1970"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 918 Spyder",
+    "year": "2014"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 944 Turbo",
+    "year": "1989"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 968 Turbo S",
+    "year": "1993"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche 959",
+    "year": "1987"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Carrera GT",
+    "year": "2003"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Cayenne Turbo",
+    "year": "2018"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Cayman GT4",
+    "year": "2016"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Cayman GTS",
+    "year": "2015"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Macan LPR Rally Raid",
+    "year": "2018"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Macan Turbo",
+    "year": "2019"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Mission R",
+    "year": "2021"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Panamera Turbo",
+    "year": "2017"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Taycan Cross Turismo Turbo S",
+    "year": "2023"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Taycan Turbo S",
+    "year": "2020"
+  },
+  {
+    "brand": "Porsche",
+    "model": "Porsche Taycan Turbo S \"Welcome Pack\"",
+    "year": "2020"
+  },
+  {
+    "brand": "Radical",
+    "model": "Radical RXC Turbo",
+    "year": "2015"
+  },
+  {
+    "brand": "RAESR",
+    "model": "RAESR Tachyon Speed",
+    "year": "2019"
+  },
+  {
+    "brand": "RAM",
+    "model": "RAM 2500 Power Wagon",
+    "year": "2017"
+  },
+  {
+    "brand": "Reliant",
+    "model": "Reliant Supervan III",
+    "year": "1972"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault 4L Export",
+    "year": "1968"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault 5 Turbo",
+    "year": "1980"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault 8 Gordini",
+    "year": "1967"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Clio R.S.",
+    "year": "2010"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Clio R.S. 16 Concept",
+    "year": "2016"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Clio R.S. 200 EDC",
+    "year": "2013"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Clio Williams",
+    "year": "1993"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Megane R.S.",
+    "year": "2018"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Megane RS 250",
+    "year": "2010"
+  },
+  {
+    "brand": "Renault",
+    "model": "Renault Mégane R26.R",
+    "year": "2008"
+  },
+  {
+    "brand": "Rimac",
+    "model": "Rimac Concept Two",
+    "year": "2019"
+  },
+  {
+    "brand": "Rimac",
+    "model": "Rimac Nevera",
+    "year": "2021"
+  },
+  {
+    "brand": "Rivian",
+    "model": "Rivian R1S",
+    "year": "2022"
+  },
+  {
+    "brand": "Rivian",
+    "model": "Rivian R1T",
+    "year": "2022"
+  },
+  {
+    "brand": "RJ",
+    "model": "RJ Anderson #37 Polaris RZR-Rockstar Energy Pro 2 Truck",
+    "year": "2016"
+  },
+  {
+    "brand": "RJ",
+    "model": "RJ Anderson #37 Polaris RZR Pro 4 Truck",
+    "year": "2021"
+  },
+  {
+    "brand": "Rossion",
+    "model": "Rossion Q1",
+    "year": "2010"
+  },
+  {
+    "brand": "Saleen",
+    "model": "Saleen S1",
+    "year": "2018"
+  },
+  {
+    "brand": "Saleen",
+    "model": "Saleen S7",
+    "year": "2004"
+  },
+  {
+    "brand": "Saleen",
+    "model": "Saleen S7 LM",
+    "year": "2017"
+  },
+  {
+    "brand": "Saleen",
+    "model": "Saleen Sportruck XR Black Label",
+    "year": "2020"
+  },
+  {
+    "brand": "Schuppan",
+    "model": "Schuppan 962CR",
+    "year": "1993"
+  },
+  {
+    "brand": "Shelby",
+    "model": "Shelby Cobra 427 S/C",
+    "year": "1965"
+  },
+  {
+    "brand": "Shelby",
+    "model": "Shelby Cobra Daytona Coupé",
+    "year": "1965"
+  },
+  {
+    "brand": "Shelby",
+    "model": "Shelby GT 500",
+    "year": "1967"
+  },
+  {
+    "brand": "SIERRA",
+    "model": "SIERRA Cars #23 Yokohama Alpha",
+    "year": "2020"
+  },
+  {
+    "brand": "SIERRA",
+    "model": "SIERRA Cars 700R",
+    "year": "2021"
+  },
+  {
+    "brand": "SIERRA",
+    "model": "SIERRA Cars RX3",
+    "year": "2021"
+  },
+  {
+    "brand": "Spania",
+    "model": "Spania GTA GTA Spano",
+    "year": "2016"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU BRAT GL",
+    "year": "1980"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU BRZ",
+    "year": "2013"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU BRZ",
+    "year": "2022"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU Impreza 22B-STi Version",
+    "year": "1998"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU Impreza WRX STi",
+    "year": "2004"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU Impreza WRX STi",
+    "year": "2005"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU Impreza WRX STI",
+    "year": "2008"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU Legacy RS",
+    "year": "1990"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU STI S209",
+    "year": "2019"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU SVX",
+    "year": "1996"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU WRX",
+    "year": "2022"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU WRX STI",
+    "year": "2011"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU WRX STI",
+    "year": "2015"
+  },
+  {
+    "brand": "SUBARU",
+    "model": "SUBARU WRX STI ARX Supercar",
+    "year": "2018"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota #1 T100 Baja Truck",
+    "year": "1993"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota 2000GT",
+    "year": "2000"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota 4Runner TRD Pro",
+    "year": "2019"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota 86",
+    "year": "2013"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Camry TRD",
+    "year": "2023"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Celica GT",
+    "year": "1974"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Celica GT-Four RC ST185",
+    "year": "1992"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Celica GT-Four ST205",
+    "year": "1994"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Celica Sport Specialty II",
+    "year": "2003"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Chaser GT Twin Turbo",
+    "year": "1991"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota FJ40",
+    "year": "1979"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota GR Supra",
+    "year": "2020"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota GR Yaris",
+    "year": "2021"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota GR86",
+    "year": "2022"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Hilux Arctic Trucks AT38",
+    "year": "2007"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Land Cruiser Arctic Trucks AT37",
+    "year": "2016"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota MR2 GT",
+    "year": "1995"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota MR2 SC",
+    "year": "1989"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Sera",
+    "year": "1991"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Soarer 2.5 GT-T",
+    "year": "1997"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Sports 800",
+    "year": "1965"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Sprinter Trueno GT Apex",
+    "year": "1985"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Supra 2.0 GT",
+    "year": "1992"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Supra RZ",
+    "year": "1998"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Supra RZ \"Welcome Pack\"",
+    "year": "1998"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Tacoma TRD Pro",
+    "year": "2019"
+  },
+  {
+    "brand": "Toyota",
+    "model": "Toyota Tundra TRD Pro",
+    "year": "2020"
+  },
+  {
+    "brand": "TVR",
+    "model": "TVR Cerbera Speed 12",
+    "year": "1998"
+  },
+  {
+    "brand": "TVR",
+    "model": "TVR Griffith",
+    "year": "2018"
+  },
+  {
+    "brand": "TVR",
+    "model": "TVR Sagaris",
+    "year": "2005"
+  },
+  {
+    "brand": "Ultima",
+    "model": "Ultima Evolution Coupe 1020",
+    "year": "2015"
+  },
+  {
+    "brand": "Universal",
+    "model": "Universal Studios Back to the Future Time Machine 1",
+    "year": "1981"
+  },
+  {
+    "brand": "Universal",
+    "model": "Universal Studios Back to the Future Time Machine 2",
+    "year": "1981"
+  },
+  {
+    "brand": "Universal",
+    "model": "Universal Studios Back to the Future Time Machine 3",
+    "year": "1981"
+  },
+  {
+    "brand": "Universal",
+    "model": "Universal Studios Jeep Wrangler Sahara 'Jurassic Park'",
+    "year": "1992"
+  },
+  {
+    "brand": "Universal",
+    "model": "Universal Studios K.I.T.T.",
+    "year": "1982"
+  },
+  {
+    "brand": "Vauxhall",
+    "model": "Vauxhall Corsa VXR",
+    "year": "2016"
+  },
+  {
+    "brand": "Vauxhall",
+    "model": "Vauxhall Lotus Carlton",
+    "year": "1990"
+  },
+  {
+    "brand": "Vauxhall",
+    "model": "Vauxhall Monaro VXR",
+    "year": "2005"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen #34 Volkswagen Andretti Rallycross Beetle",
+    "year": "2017"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen #1107 Desert Dingo Racing Stock Bug",
+    "year": "1970"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Beetle",
+    "year": "1963"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Beetle Forza Edition",
+    "year": "1963"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Class 5/1600 Baja Bug",
+    "year": "1969"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Corrado VR6",
+    "year": "1995"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Double Cab Pick-Up",
+    "year": "1966"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf GTI",
+    "year": "1983"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf Gti 16v Mk2",
+    "year": "1992"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf R",
+    "year": "2010"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf R",
+    "year": "2014"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf R",
+    "year": "2021"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf R",
+    "year": "2022"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Golf R32",
+    "year": "2003"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen GTI VR6 Mk3",
+    "year": "1998"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen ID.4",
+    "year": "2021"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Pickup LX",
+    "year": "1982"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Santana",
+    "year": "2012"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Scirocco R",
+    "year": "2011"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Scirocco S",
+    "year": "1981"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen SP-2",
+    "year": "1976"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Thing",
+    "year": "1973"
+  },
+  {
+    "brand": "Volkswagen",
+    "model": "Volkswagen Type 2 De Luxe",
+    "year": "1963"
+  },
+  {
+    "brand": "Volvo",
+    "model": "Volvo 242 Turbo Evolution",
+    "year": "1983"
+  },
+  {
+    "brand": "Volvo",
+    "model": "Volvo 850 R",
+    "year": "1997"
+  },
+  {
+    "brand": "Volvo",
+    "model": "Volvo C30 Polestar",
+    "year": "2013"
+  },
+  {
+    "brand": "Volvo",
+    "model": "Volvo V60 Polestar",
+    "year": "2015"
+  },
+  {
+    "brand": "VUHL",
+    "model": "VUHL 05RR",
+    "year": "2017"
+  },
+  {
+    "brand": "W",
+    "model": "W Motors Lykan HyperSport",
+    "year": "2016"
+  },
+  {
+    "brand": "Willys",
+    "model": "Willys MB Jeep",
+    "year": "1945"
+  },
+  {
+    "brand": "Wuling",
+    "model": "Wuling Hongguang Mini EV Macaron",
+    "year": "2022"
+  },
+  {
+    "brand": "Wuling",
+    "model": "Wuling Sunshine S",
+    "year": "2013"
+  },
+  {
+    "brand": "Xpeng",
+    "model": "Xpeng P7",
+    "year": "2020"
+  },
+  {
+    "brand": "Zenvo",
+    "model": "Zenvo ST1",
+    "year": "2016"
+  },
+  {
+    "brand": "Zenvo",
+    "model": "Zenvo TSR-S",
+    "year": "2019"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Forza Horizon 5 Cars</title>
+<style>
+body { font-family: Arial, sans-serif; }
+.brand { margin-top: 20px; }
+.brand h2 { border-bottom: 1px solid #ccc; }
+</style>
+</head>
+<body>
+<h1>Forza Horizon 5 Cars</h1>
+<div id="content">Loading...</div>
+<script>
+fetch('data/fh5_cars.json')
+  .then(res => res.json())
+  .then(cars => {
+    const brands = {};
+    cars.forEach(c => {
+      if (!brands[c.brand]) brands[c.brand] = [];
+      brands[c.brand].push(c);
+    });
+    const container = document.getElementById('content');
+    container.textContent = '';
+    Object.keys(brands).sort().forEach(brand => {
+      const div = document.createElement('div');
+      div.className = 'brand';
+      const h2 = document.createElement('h2');
+      h2.textContent = brand;
+      div.appendChild(h2);
+      const ul = document.createElement('ul');
+      brands[brand].forEach(car => {
+        const li = document.createElement('li');
+        li.textContent = `${car.model} (${car.year})`;
+        ul.appendChild(li);
+      });
+      div.appendChild(ul);
+      container.appendChild(div);
+    });
+  })
+  .catch(err => {
+    document.getElementById('content').textContent = 'Failed to load car data.';
+  });
+</script>
+</body>
+</html>

--- a/scripts/extract_cars.py
+++ b/scripts/extract_cars.py
@@ -1,0 +1,27 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+import re
+
+def fetch_cars(url='https://forza.fandom.com/wiki/Forza_Horizon_5/Cars'):
+    res = requests.get(url)
+    res.raise_for_status()
+    soup = BeautifulSoup(res.text, 'html.parser')
+    table = soup.find_all('table')[1]
+    cars = []
+    for row in table.find_all('tr')[1:]:
+        link = row.find('a')
+        if not link:
+            continue
+        model = link.text.strip()
+        year_match = re.search(r'(19|20)\d{2}', row.text)
+        year = year_match.group(0) if year_match else ''
+        brand = model.split()[0]
+        cars.append({'brand': brand, 'model': model, 'year': year})
+    return cars
+
+if __name__ == '__main__':
+    cars = fetch_cars()
+    with open('data/fh5_cars.json', 'w', encoding='utf-8') as f:
+        json.dump(cars, f, ensure_ascii=False, indent=2)
+    print(f'Saved {len(cars)} cars to data/fh5_cars.json')


### PR DESCRIPTION
## Summary
- scrape Forza Horizon 5 car list from Fandom
- generate dataset under `data/`
- add simple HTML page grouping cars by brand

## Testing
- `python3 scripts/extract_cars.py`

------
https://chatgpt.com/codex/tasks/task_b_6887022b847083248384b26d6e6ae6ec